### PR TITLE
Guard::Rspec::Formatter is now a class, not a module

### DIFF
--- a/lib/guard/jruby-rspec/formatters/notification_rspec.rb
+++ b/lib/guard/jruby-rspec/formatters/notification_rspec.rb
@@ -1,8 +1,6 @@
 require "guard/rspec/formatter"
-require "rspec/core/formatters/base_formatter"
 
-class Guard::JRubyRSpec::Formatter::NotificationRSpec < RSpec::Core::Formatters::BaseFormatter
-  include Guard::RSpec::Formatter
+class Guard::JRubyRSpec::Formatter::NotificationRSpec < Guard::RSpec::Formatter
 
   def dump_summary(duration, total, failures, pending)
     message = guard_message(total, failures, pending, duration)


### PR DESCRIPTION
This corresponds to a guard-rspec change that made the formatter a class
instead of a module:
  https://github.com/guard/guard-rspec/commit/31e1be02503c51ed37aeda486866550f7f8395d2

This fixed #15 for me.
