### PR TITLE
Guard 1.1 renamed run_on_change to run_on_changes

### DIFF
--- a/lib/guard/jruby-rspec.rb
+++ b/lib/guard/jruby-rspec.rb
@@ -49,7 +49,7 @@ module Guard
       run_all if @options[:all_on_start]
     end
 
-    def run_on_change(raw_paths)
+    def run_on_changes(raw_paths)
       reload_paths(raw_paths)
 
       unless @custom_watchers.nil? or @custom_watchers.empty?
@@ -65,6 +65,8 @@ module Guard
         super(paths)
       end
     end
+    # Guard 1.1 renamed run_on_change to run_on_changes
+    alias_method :run_on_change, :run_on_changes
 
     def reload_paths(paths)
       paths.each do |p| 


### PR DESCRIPTION
Since this gem doesn't have a hard dependency, this patch provides compatibility for either hook.

For me, this fixes #9 and has it picking up changes to files other then spec files both in and out of Rails on the latest Guard and Guard-RSpec.
