### PR TITLE
Prevent spec from running twice when spec file was changed

### DIFF
--- a/lib/guard/jruby-rspec.rb
+++ b/lib/guard/jruby-rspec.rb
@@ -9,12 +9,13 @@ module Guard
 
     def initialize(watchers = [], options = {})
       @options = {
-        :all_after_pass => true,
-        :all_on_start   => true,
-        :keep_failed    => true,
-        :spec_paths     => ["spec"],
-        :run_all        => {},
-        :monitor_file   => ".guard-jruby-rspec"
+        :all_after_pass   => true,
+        :all_on_start     => true,
+        :keep_failed      => true,
+        :spec_paths       => ["spec"],        
+        :spec_file_suffix => "_spec.rb",
+        :run_all          => {},
+        :monitor_file     => ".guard-jruby-rspec"
       }.merge(options)
       @last_failed  = false
       @failed_paths = []
@@ -69,7 +70,7 @@ module Guard
     alias_method :run_on_change, :run_on_changes
 
     def reload_paths(paths)
-      paths.each do |p| 
+      paths.reject {|p| p.end_with?(@options[:spec_file_suffix])}.each do |p| 
         if File.exists?(p) 
           if p == @options[:monitor_file]
             # begin

--- a/spec/guard/jruby-rspec_spec.rb
+++ b/spec/guard/jruby-rspec_spec.rb
@@ -105,6 +105,31 @@ describe Guard::JRubyRSpec do
     it_should_behave_like 'clear failed paths'
   end
 
+  describe '#reload_paths' do
+
+    it 'should reload files other than spec files' do
+      lib_file = 'lib/myapp/greeter.rb'
+      spec_file = 'specs/myapp/greeter_spec.rb'
+      File.stub(:exists?).and_return(true)
+      subject.stub(:load)
+      subject.should_receive(:load).with(lib_file)
+      subject.should_not_receive(:load).with(spec_file)
+
+      subject.reload_paths([lib_file, spec_file])
+    end
+
+    it 'should use @options to alter spec file suffix' do
+      subject = described_class.new([], :spec_file_suffix => '_test.rb')
+      test_file = 'specs/myapp/greeter_test.rb'
+      File.stub(:exists?).and_return(true)
+      subject.stub(:load)
+      subject.should_not_receive(:load).with(test_file)
+
+      subject.reload_paths([test_file])
+    end
+
+  end
+
   describe '#run_on_change' do
     before { inspector.stub(:clean => ['spec/foo_match']) }
 


### PR DESCRIPTION
RSpec when run in embedded mode via RSpec::Core::Runner reloads spec files itself. Loading it one more time before specs are run causes specs to run twice. Lib files still need to be reloaded explicitly.
