### PR TITLE
Keep RSpec configuration between runs

### DIFF
--- a/lib/guard/jruby-rspec/runner.rb
+++ b/lib/guard/jruby-rspec/runner.rb
@@ -4,7 +4,7 @@ require 'guard/jruby-rspec/formatters/notification_rspec'
 module Guard
   class JRubyRSpec
     class Runner
-     
+
       def initialize(options = {})
         @options = {
           :cli          => [],
@@ -27,10 +27,10 @@ module Guard
         UI.info(message, :reset => true)
 
         # it might be a problem to run Rspec within this runtime.  Might have to create an
-        # embedded jruby.  
+        # embedded jruby.
         if File.exists?(@pipefile)
           raise "not supported yet"
-          # instead of writing to the pipefile, we should probably use a 
+          # instead of writing to the pipefile, we should probably use a
           # formatter and write to /dev/null
           # orig_stdout = $stdout.clone
           # orig_stderr = $stderr.clone
@@ -43,10 +43,13 @@ module Guard
           #   $stderr.reopen(orig_stderr)
           # end
         else
+          orig_configuration = ::RSpec.configuration
           begin
             ::RSpec::Core::Runner.run(rspec_arguments(paths, @options))
           rescue SyntaxError => e
             UI.error e.message
+          ensure
+            ::RSpec.instance_variable_set(:@configuration, orig_configuration)
           end
         end
       end

--- a/spec/guard/jruby-rspec/runner_spec.rb
+++ b/spec/guard/jruby-rspec/runner_spec.rb
@@ -11,6 +11,14 @@ describe Guard::JRubyRSpec::Runner do
       Guard::JRubyRSpec::Runner::UI.stub(:info)
     end
 
+    it 'keeps the RSpec global configuration between runs' do
+      RSpec::Core::Runner.stub(:run)
+      orig_configuration = ::RSpec.configuration
+      ::RSpec.should_receive(:instance_variable_set).with(:@configuration, orig_configuration)
+
+      subject.run(['spec/foo'])
+    end
+
     context 'when passed an empty paths list' do
       it 'returns false' do
         subject.run([]).should be_false
@@ -24,6 +32,5 @@ describe Guard::JRubyRSpec::Runner do
         subject.run(['spec/foo'])
       end
     end
-
   end
 end


### PR DESCRIPTION
RSpec resets the world and configuration objects after each run
(https://github.com/rspec/rspec-core/blob/master/lib/rspec/core/runner.rb#L83). All custom helpers and matchers aren't accessible after reset.

So it's better to keep the RSpec's configuration defined in spec_helper.rb, because this
file is loaded only one (before the first run).

It should fix issues #13 and #19.
