### PR TITLE
Silence logger output during test runs

### DIFF
--- a/spec/guard/jruby-rspec_spec.rb
+++ b/spec/guard/jruby-rspec_spec.rb
@@ -26,6 +26,7 @@ describe Guard::JRubyRSpec do
   before do
     described_class::Runner.stub(:new => runner)
     described_class::Inspector.stub(:new => inspector)
+    Guard::UI.stub(:info)
   end
 
   shared_examples_for 'clear failed paths' do


### PR DESCRIPTION
This patch silences calls to `Guard::UI.info` that output "INFO - Guard::JRuby::RSpec is running, with RSpec!" during the tests.

Before:
![screen shot 2013-05-15 at 3 10 52 pm](https://f.cloud.github.com/assets/64751/508862/54f00ec2-bd93-11e2-9580-66af28082894.png)

After:
![screen shot 2013-05-15 at 3 13 02 pm](https://f.cloud.github.com/assets/64751/508870/b494a630-bd93-11e2-8485-5fb44e995343.png)

Alternatively, this could be changed to expect those calls to `info` in the tests that call them, but I would prefer the flexibility.
