### PR TITLE
Prevent load errors from killing the jruby-rspec guard

### DIFF
--- a/lib/guard/jruby-rspec.rb
+++ b/lib/guard/jruby-rspec.rb
@@ -85,7 +85,13 @@ module Guard
             # end
           else
             # reload the file
-            load p 
+            begin
+              load p
+            rescue
+              UI.error $!.message
+              UI.error $!.backtrace.join "\n"
+              throw :task_has_failed
+            end
           end
         end
       end

--- a/spec/guard/jruby-rspec_spec.rb
+++ b/spec/guard/jruby-rspec_spec.rb
@@ -131,6 +131,15 @@ describe Guard::JRubyRSpec do
       subject.reload_paths([test_file])
     end
 
+    it 'recovers from exceptions raised when loading files' do
+      lib_file = 'lib/myapp/greeter.rb'
+      File.stub(:exists?).and_return(true)
+      subject.stub(:load).and_raise("This fires and deactivates the jruby-rspec guard")
+      Guard::UI.should_receive(:error).any_number_of_times
+      expect {
+        subject.reload_paths([lib_file])
+      }.to throw_symbol(:task_has_failed)
+    end
   end
 
   describe '#run_on_change' do


### PR DESCRIPTION
After guard starts, if a class was changed in a way that caused an error to be raised on load, the error was raising up into the guard stack, which caused the jruby-rspec guard to get [fired / deactivated](https://github.com/guard/guard/blob/ee133a6b1ef8f9eb20243545b456c618440543cb/lib/guard/runner.rb#L102). Guard needed to be reloaded to continue testing.

```
20:30:52 - ERROR - Guard::JRubyRSpec failed to achieve its <run_on_changes>, exception was:
> [#] NameError: undefined local variable or method `crap' for #<Class:0x239e06d7>
> [#] org/jruby/RubyKernel.java:227:in `method_missing'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/.bundle/jruby/1.8/gems/activerecord-3.2.12/lib/active_record/dynamic_matchers.rb:55:in `method_missing'
> [#] ./app/models/address.rb:2:in `Address'
> [#] ./app/models/address.rb:1:in `(root)'
> [#] org/jruby/RubyKernel.java:1058:in `load'
> [#] org/jruby/RubyMethod.java:133:in `call'
> [#] ./app/models/address.rb:88:in `reload_paths'
> [#] org/jruby/RubyArray.java:1615:in `each'
> [#] /vagrant/git/guard-jruby-rspec/lib/guard/jruby-rspec.rb:73:in `reload_paths'
> [#] /vagrant/git/guard-jruby-rspec/lib/guard/jruby-rspec.rb:54:in `run_on_changes'
> [#] org/jruby/RubyKernel.java:2080:in `send'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:99:in `run_supervised_task'
> [#] org/jruby/RubyKernel.java:1183:in `catch'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:97:in `run_supervised_task'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:144:in `run_first_task_found'
> [#] org/jruby/RubyArray.java:1615:in `each'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:142:in `run_first_task_found'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:79:in `run_on_changes'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:175:in `scoped_guards'> [#] org/jruby/RubyArray.java:1615:in `each'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:173:in `scoped_guards'
> [#] org/jruby/RubyKernel.java:1183:in `catch'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:172:in `scoped_guards'
> [#] org/jruby/RubyArray.java:1615:in `each'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:170:in `scoped_guards'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard/runner.rb:72:in `run_on_changes'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard.rb:105:in `setup_listener'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard.rb:368:in `within_preserved_state'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard.rb:365:in `within_preserved_state'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/guard-1.8.0/lib/guard.rb:104:in `setup_listener'
> [#] org/jruby/RubyProc.java:270:in `call'
> [#] org/jruby/RubyProc.java:220:in `call'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/listen-1.0.2/lib/listen/listener.rb:234:in `on_change'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/listen-1.0.2/lib/listen/listener.rb:266:in `initialize_adapter'
> [#] org/jruby/RubyProc.java:270:in `call'
> [#] org/jruby/RubyProc.java:220:in `call'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/listen-1.0.2/lib/listen/adapters/polling.rb:48:in `poll_changed_directories'
> [#] /home/vagrant/ws/rental_express/ROOT/rails/vendor/gems/listen-1.0.2/lib/listen/adapter.rb:284:in `start_poller'
> [#] org/jruby/RubyProc.java:270:in `call'
> [#] org/jruby/RubyProc.java:224:in `call'
21:13:33 - INFO - Guard::JRubyRSpec has just been fired
```

This patch instead outputs the error and its stacktrace using `Guard::UI.error`, cancels the current test run, and continues listening for changes.
