### PR TITLE
bug: Array of test helpers in custom watcher gives error

### DIFF
--- a/lib/guard/jruby-rspec.rb
+++ b/lib/guard/jruby-rspec.rb
@@ -71,7 +71,7 @@ module Guard
             end
           end
         end
-        super(paths)
+        super(paths.flatten)
       end
     end
     # Guard 1.1 renamed run_on_change to run_on_changes

--- a/spec/guard/jruby-rspec_spec.rb
+++ b/spec/guard/jruby-rspec_spec.rb
@@ -223,6 +223,18 @@ describe Guard::JRubyRSpec do
       expect { subject.run_on_change(['spec/foo']) }.to throw_symbol :task_has_failed
     end
 
+    it "works with watchers that have an array of test targets" do
+      subject = described_class.new([Guard::Watcher.new(%r{^spec/(.+)$}, lambda { |m| ["spec/#{m[1]}_match", "spec/#{m[1]}_another.rb"]})])
+
+      test_targets = ["spec/quack_spec_match", "spec/quack_spec_another.rb"]
+
+      inspector.should_receive(:clean).with(test_targets).and_return(test_targets)
+      runner.should_receive(:run).with(test_targets) { true }
+      subject.run_on_change(['spec/quack_spec'])
+
+    end
+
+
     it "works with watchers that don't have an action" do
       subject = described_class.new([Guard::Watcher.new(%r{^spec/(.+)$})])
 


### PR DESCRIPTION
- If a custom watcher returns an array, it will error.
- Flattened the array of paths in run_on_changes that is passed up to super

This is my attempt at fixing [Issue #34](https://github.com/jkutner/guard-jruby-rspec/issues/34) It was a pretty easy fix, and I am relatively sure my test catches what it needs to catch.  Also, I pulled this into my project and it fixed the problem.  

Let me know if I need to take a different approach or if I messed something up.
