### PR TITLE
RSpec 3 support via guard-rspec-1.x

### DIFF
--- a/guard-jruby-rspec.gemspec
+++ b/guard-jruby-rspec.gemspec
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
   s.rubyforge_project         = 'guard-jruby-rspec'
 
   s.add_dependency 'guard', '>= 0.10.0', '< 2.0.0'
-  s.add_dependency 'guard-rspec', '>= 2.0.0', '< 4.0.0'
-  s.add_dependency 'rspec', '~> 2.7', '< 2.99'
+  s.add_dependency 'guard-rspec', '>= 0.7.3', '< 4.0.0'
+
+  s.add_development_dependency 'rspec', '~> 2.7'
 
   s.files        = Dir.glob('{lib}/**/*') + %w[LICENSE README.md]
   s.require_path = 'lib'

--- a/lib/guard/jruby-rspec/formatters/notification_rspec.rb
+++ b/lib/guard/jruby-rspec/formatters/notification_rspec.rb
@@ -1,6 +1,15 @@
 require "guard/rspec/formatter"
 
-class Guard::JRubyRSpec::Formatter::NotificationRSpec < Guard::RSpec::Formatter
+superclass = if Guard::RSpec::Formatter.instance_of? Module # guard-rspec-1.x
+               Object
+             elsif Guard::RSpec::Formatter.instance_of? Class # guard-rspec-2.x
+               Guard::RSpec::Formatter
+             else
+               fail 'Guard::RSpec::Formatter is neither class nor module'
+             end
+
+class Guard::JRubyRSpec::Formatter::NotificationRSpec < superclass
+  include Guard::RSpec::Formatter if Guard::RSpec::Formatter.instance_of? Module
 
   def dump_summary(duration, total, failures, pending)
     message = guard_message(total, failures, pending, duration)


### PR DESCRIPTION
Until #38 is implemented for guard-rspec 5.x / guard 2.x compatibility, we're stuck with guard-rspec < 4.0. guard-rspec 1.x is the only version in this range that does not have a runtime dependency on rspec 2. guard-rspec 2.0.0 introduced a runtime dependency on rspec 2 when it [started using RSpec's options parser](https://github.com/guard/guard-rspec/commit/11fea49e924d1ab213d0ca1fc5b6a52a4a68cc45%5E).

In addition, guard-rspec-2.0.0 changed `Guard::RSpec::Formatter` [from a module to a class](https://github.com/guard/guard-rspec/commit/31e1be02503c51ed37aeda486866550f7f8395d2#diff-5). guard-jruby-rspec addressed that change in 5f8ec60a6c9237ae216119e0542941a1bc79c82b but did not update its gem dependency to exclude guard-rspec < 2.0.0 as a compatible version, nor did it continue to support the old version, where it was a module. I fixed this in 64a04f9, now in master.

My goal is to support both guard-rspec versions 1-3, as the gemspec reports to. Then bundler can resolve guard-rspec 1 + rspec 3 or guard-rspec 2/3 + rspec 2. 